### PR TITLE
Tool ID fixes for Ollama and Gemini (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,6 +981,16 @@ htop  # Check CPU/Memory during execution
 # - Using GPU acceleration if available
 ```
 
+#### macOS duplicate dynamic library loading errors
+```bash
+# Accept for embedding libraries
+export KMP_DUPLICATE_LIB_OK=TRUE
+
+# Diagnose which libraries are loading
+export DYLD_PRINT_LIBRARIES=1
+export DYLD_PRINT_RPATHS=1
+```
+
 ## Contributing
 
 1. Fork the repository

--- a/benchmark_harness/README.md
+++ b/benchmark_harness/README.md
@@ -16,6 +16,7 @@ docker compose --env-file ../.env up -d --no-deps cyber-autoagent
 ## XBOW Benchmarks
 
 Checkout one of the benchmark repos:
+- `git clone --depth=1 https://github.com/double16/validation-benchmarks.git`
 - `git clone --depth=1 https://github.com/schniggie/validation-benchmarks.git`
 - `git clone --depth=1 https://github.com/xbow-engineering/validation-benchmarks.git`
 

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -31,6 +31,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY docker/apt_proxy_configure.sh docker/apt_proxy_clean.sh /tmp/
 
 RUN set -eux; \
+    touch /root/.hushlogin && \
     /tmp/apt_proxy_configure.sh && \
     mirrors="ftp.acc.umu.se/mirror/kali.org/kali mirror.math.princeton.edu/pub/kali kali.mirror.garr.it/mirrors/kali mirror.pit.teraswitch.com/kali"; \
     success=0; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "standard-distutils>=3.11.9",
     "guppy3~=3.1.5",
     "validators>=0.35.0",
-    "ddgs~=9.6.1",
+    "ddgs~=9.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/modules/agents/__init__.py
+++ b/src/modules/agents/__init__.py
@@ -2,5 +2,16 @@
 
 from modules.agents.cyber_autoagent import check_existing_memories, create_agent
 from modules.agents.report_agent import ReportAgent, ReportGenerator
+from modules.agents.patches import patch_model_class_tool_use_id
+
+from strands.models import BedrockModel
+from strands.models.litellm import LiteLLMModel
+from strands.models.ollama import OllamaModel
+from strands.models.gemini import GeminiModel
 
 __all__ = ["create_agent", "check_existing_memories", "ReportAgent", "ReportGenerator"]
+
+patch_model_class_tool_use_id(BedrockModel)
+patch_model_class_tool_use_id(LiteLLMModel)
+patch_model_class_tool_use_id(OllamaModel)
+patch_model_class_tool_use_id(GeminiModel)

--- a/src/modules/agents/patches.py
+++ b/src/modules/agents/patches.py
@@ -1,0 +1,162 @@
+"""
+These are monkey patches to handle inconsistencies in some providers.
+
+We require a unique ID per tool call. There `toolUseId` and `id` properties are candidates. `toolUseId` is used by
+some providers for the tool name and strands ignores the `id` property. We modify the flow such that before a tool is
+processed we detect this case and replace `toolUseId` with a unique value. Before sending the result back to the model,
+we revert this or the model will do strange things like think the unique ID is a tool name that can be called. The
+important parts of the flow are:
+
+1. prompt sent to model
+2. streaming response starts  <-- we need to patch the ID here by modifying the events
+3. SDK event received by our handler
+4. BeforeToolCallEvent hooks processed
+5. AfterToolCallEvent hooks processed  <-- we need to revert here because hooks are allowed to change response content
+6. SDK event received by our handler  <-- additional property _toolUseId is accepted here because it doesn't interfere with the model
+7. Tool results sent to model
+
+"""
+from __future__ import annotations
+
+import functools
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable, Optional, Type
+from uuid import uuid4
+from strands.hooks.events import AfterToolCallEvent
+from strands.hooks import HookProvider, HookRegistry
+
+
+@dataclass
+class _ToolUseIdStreamState:
+    current_tool_use_id: Optional[str] = None
+
+
+def patch_model_class_tool_use_id(
+        model_cls: Type[Any],
+        *,
+        is_bad_id: Optional[Callable[[Optional[str], Optional[str]], bool]] = None,
+        id_factory: Optional[Callable[[], str]] = None,
+        attr_prefix: str = "_tooluseid_class_patch",
+) -> Type[Any]:
+    """
+    Monkey-patch model_cls.stream at the *class* level so toolUseId is unique per invocation.
+
+    Patches tool-use IDs in these event shapes (covers common Strands provider normalizations):
+      - ev["contentBlockStart"]["start"]["toolUse"]   (Bedrock-ish)
+      - ev["contentBlockDelta"]["delta"]["toolUse"]   (Bedrock-ish)
+      - ev["current_tool_use"]                        (Strands callback convenience)
+
+    Idempotent: safe to call multiple times.
+
+    Returns:
+      model_cls (patched)
+    """
+    enabled_attr = f"{attr_prefix}_enabled"
+    orig_attr = f"{attr_prefix}_orig_stream"
+
+    if getattr(model_cls, enabled_attr, False):
+        return model_cls
+
+    if not hasattr(model_cls, "stream"):
+        raise TypeError(f"{model_cls.__name__} has no 'stream' method to patch")
+
+    if is_bad_id is None:
+        def is_bad_id(tool_use_id: Optional[str], tool_name: Optional[str]) -> bool:
+            # Treat missing/empty OR "id == tool name" as bad (your reported symptom)
+            if not tool_use_id:
+                return True
+            if tool_name and tool_use_id == tool_name:
+                return True
+            return False
+
+    if id_factory is None:
+        id_factory = lambda: f"tooluse_{uuid4().hex}"
+
+    orig_stream = getattr(model_cls, "stream")
+    setattr(model_cls, orig_attr, orig_stream)
+
+    @functools.wraps(orig_stream)
+    async def stream_patched(self: Any, *args: Any, **kwargs: Any) -> AsyncIterator[dict]:
+        state = _ToolUseIdStreamState()
+
+        async for ev in orig_stream(self, *args, **kwargs):
+            # --- Pattern A: contentBlockStart -> toolUse ---
+            cbs = ev.get("contentBlockStart")
+            if isinstance(cbs, dict):
+                start = cbs.get("start")
+                if isinstance(start, dict):
+                    tool_use = start.get("toolUse")
+                    if isinstance(tool_use, dict):
+                        name = tool_use.get("name")
+                        tuid = tool_use.get("toolUseId")
+                        if is_bad_id(tuid, name):
+                            if not name:
+                                tool_use["name"] = tuid
+                            tuid = id_factory()
+                            tool_use["_toolUseId"] = tool_use["toolUseId"] = tuid
+                        state.current_tool_use_id = tuid
+
+            # --- Pattern B: contentBlockDelta -> toolUse (keep consistent) ---
+            cbd = ev.get("contentBlockDelta")
+            if isinstance(cbd, dict):
+                delta = cbd.get("delta")
+                if isinstance(delta, dict):
+                    dtu = delta.get("toolUse")
+                    if isinstance(dtu, dict):
+                        name = dtu.get("name")
+                        tuid = dtu.get("toolUseId")
+                        if (name or tuid) and is_bad_id(tuid, name) and state.current_tool_use_id:
+                            dtu["_toolUseId"] = dtu["toolUseId"] = state.current_tool_use_id
+
+            # --- Pattern C: Strands convenience field current_tool_use ---
+            ctu = ev.get("current_tool_use")
+            if isinstance(ctu, dict):
+                name = ctu.get("name")
+                tuid = ctu.get("toolUseId")
+                if is_bad_id(tuid, name):
+                    if not name:
+                        ctu["name"] = tuid
+                    tuid = state.current_tool_use_id or id_factory()
+                    ctu["_toolUseId"] = ctu["toolUseId"] = tuid
+                state.current_tool_use_id = tuid
+
+            yield ev
+
+    setattr(model_cls, "stream", stream_patched)
+    setattr(model_cls, enabled_attr, True)
+    return model_cls
+
+
+def unpatch_model_class_tool_use_id(
+        model_cls: Type[Any],
+        *,
+        attr_prefix: str = "_tooluseid_class_patch",
+) -> Type[Any]:
+    """Restore the original model_cls.stream if it was patched by patch_model_class_tool_use_id()."""
+    enabled_attr = f"{attr_prefix}_enabled"
+    orig_attr = f"{attr_prefix}_orig_stream"
+
+    if getattr(model_cls, enabled_attr, False) and hasattr(model_cls, orig_attr):
+        setattr(model_cls, "stream", getattr(model_cls, orig_attr))
+        setattr(model_cls, enabled_attr, False)
+    return model_cls
+
+
+class ToolUseIdHook(HookProvider):
+    def register_hooks(self, registry: "HookRegistry", **kwargs: Any) -> None:
+        registry.add_callback(AfterToolCallEvent, self.revert_tool_use_id)
+
+    def revert_tool_use_id(self, event: AfterToolCallEvent):
+        tool_use = getattr(event, "tool_use", {})
+        tool_name = tool_use.get("name", "")
+        tool_use_id = tool_use.get("toolUseId", "")
+
+        if tool_use_id.startswith("tooluse_") and tool_name:
+            # reverse the patch that set a generated ID because some models use toolUseId as the tool name !?!
+            tool_use["_toolUseId"] = tool_use_id
+            tool_use["toolUseId"] = tool_name
+
+            result = getattr(event, "result", None)
+            if isinstance(result, dict) and "toolUseId" in result:
+                result["_toolUseId"] = tool_use_id
+                result["toolUseId"] = tool_name

--- a/src/modules/config/providers/litellm_config.py
+++ b/src/modules/config/providers/litellm_config.py
@@ -36,8 +36,10 @@ def split_litellm_model_id(model_id: str) -> Tuple[str, str]:
         Tuple of (provider_prefix, base_model_id)
         Returns ("", model_id) if no prefix found
     """
-    if not model_id:
+    if not model_id or not isinstance(model_id, str):
         return "", ""
+    if ":" in model_id:
+        model_id, variant = model_id.split(":", maxsplit=1)
     if "/" in model_id:
         prefix, base = model_id.split("/", 1)
         # Special handling for Gemini "models/" prefix

--- a/src/modules/prompts/factory.py
+++ b/src/modules/prompts/factory.py
@@ -658,6 +658,8 @@ def get_system_prompt(
         memory_overview=memory_overview,
     )
     if plan_snapshot:
+        if len(plan_snapshot) > 1000:
+            logger.warning(f"Plan snapshot is {len(plan_snapshot)} characters")
         memory_context_text += f"\n\n## PLAN SNAPSHOT\n{plan_snapshot}"
 
     # 4. Load Tools Guide

--- a/src/modules/prompts/templates/tools_guide.md
+++ b/src/modules/prompts/templates/tools_guide.md
@@ -9,7 +9,8 @@
 **Core Rule**: Native tools > Command line > custom. Save all artifacts to OPERATION ARTIFACTS DIRECTORY (path injected above).
 
 **shell**
-- Usage: Non-interactive, parallel execution. Default timeout: 300s, heavy operations ≤600s
+- Usage: Non-interactive, parallel execution. Default timeout: 300s, heavy operations ≤600s.
+- The command, arguments and shell constructs must all be in a single string. An array of strings is used for running multiple commands.
 - Large outputs (>10KB expected: sqlmap --dump, nmap -A, nikto full scan):
   - Pipe to file: `sqlmap ... 2>&1 | tee <artifacts_path>/sqlmap_output.txt`
   - Extract relevant: `grep -E "password|hash|Database:" <artifacts_path>/sqlmap_output.txt`
@@ -30,7 +31,7 @@
   2. Evaluate criteria vs evidence
   3. Update: Criteria met → store_plan(current_phase+1, status='done') | Stuck → pivot/swarm | Partial → continue
 - Actions: store, store_plan, get_plan, get, list, retrieve, delete
-- Plan JSON: {"objective":"...", "current_phase":1, "total_phases":N, "phases":[...]}
+- Plan JSON: `{"objective":"...", "current_phase":1, "total_phases":N, "phases":[{"id":1, "title":"...", "status":"...", "criteria":"..."}, ...]}`
 - Categories: finding | signal | decision | artifact | observation | plan
 - Content: Paths only, no binary blobs
 
@@ -102,10 +103,10 @@
 - When to use: Software product and version have been identified with high confidence
 - NOT for: Do not run published proof-of-concepts, use for learning how to write own exploit
 
-- **sleep**
+**sleep**
 - Purpose: Wait for external processes to complete
 - When to use: An external process is running on the target, a tool reports to try again later
-- When NOT: Waiting for an oast_poll response (use timeout argument instead)
+- When NOT: Waiting for an `oast_poll` response (use timeout argument instead)
 
 **stop**
 - Valid: Objective achieved with artifacts OR budget ≥95% (from REFLECTION SNAPSHOT)

--- a/tests/test_agent_patches.py
+++ b/tests/test_agent_patches.py
@@ -1,0 +1,324 @@
+# test_tool_use_id_class_patch.py
+from __future__ import annotations
+
+import pytest
+
+from strands.hooks.events import AfterToolCallEvent
+from modules.agents.patches import patch_model_class_tool_use_id, unpatch_model_class_tool_use_id, ToolUseIdHook
+
+
+def _list_id_factory(ids: list[str]):
+    it = iter(ids)
+
+    def factory() -> str:
+        try:
+            return next(it)
+        except StopIteration as e:
+            raise AssertionError("id_factory called more times than expected") from e
+
+    return factory
+
+
+# ----------------------------
+# Fake models (event sources)
+# ----------------------------
+
+class FakeModelBasicBad:
+    """
+    toolUseId == name (bad) and delta repeats it.
+    """
+    async def stream(self):
+        yield {
+            "contentBlockStart": {
+                "start": {"toolUse": {"name": "mytool", "toolUseId": "mytool", "input": {"x": 1}}}
+            }
+        }
+        yield {
+            "contentBlockDelta": {
+                "delta": {"toolUse": {"name": "mytool", "toolUseId": "mytool", "input": {"x": 2}}}
+            }
+        }
+        yield {"current_tool_use": {"name": "mytool", "toolUseId": "mytool", "input": {"x": 3}}}
+
+
+class FakeModelHallucinatedName:
+    """
+    name starts with tooluse_ and toolUseId == name (bad) -> name rewritten to 'shell'
+    """
+    async def stream(self):
+        yield {
+            "contentBlockStart": {
+                "start": {"toolUse": {"name": "tooluse_abcdef", "toolUseId": "tooluse_abcdef", "input": {"x": 1}}}
+            }
+        }
+
+
+class FakeModelDeltaNoNameNoId:
+    """
+    Delta has neither name nor toolUseId -> should NOT be rewritten (guarded by (name or tuid)).
+    """
+    async def stream(self):
+        yield {
+            "contentBlockStart": {
+                "start": {"toolUse": {"name": "mytool", "toolUseId": "mytool", "input": {"x": 1}}}
+            }
+        }
+        yield {"contentBlockDelta": {"delta": {"toolUse": {"name": None, "toolUseId": None, "input": {"x": 2}}}}}
+
+
+class FakeModelAlreadyGood:
+    async def stream(self):
+        yield {
+            "contentBlockStart": {
+                "start": {"toolUse": {"name": "mytool", "toolUseId": "tooluse_abc123", "input": {"x": 1}}}
+            }
+        }
+
+
+class FakeModelMissingNameForcedBad:
+    """
+    Start event has missing/empty name but a toolUseId. We pass a custom is_bad_id to force the
+    new 'if not name: tool_use["name"] = tuid' behavior.
+    """
+    async def stream(self):
+        yield {
+            "contentBlockStart": {
+                "start": {"toolUse": {"name": "", "toolUseId": "mytool", "input": {"x": 1}}}
+            }
+        }
+        yield {"current_tool_use": {"name": "", "toolUseId": "mytool", "input": {"x": 2}}}
+
+
+# ----------------------------
+# Fixtures to undo class patch
+# ----------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_class_patches():
+    yield
+    unpatch_model_class_tool_use_id(FakeModelBasicBad)
+    unpatch_model_class_tool_use_id(FakeModelHallucinatedName)
+    unpatch_model_class_tool_use_id(FakeModelDeltaNoNameNoId)
+    unpatch_model_class_tool_use_id(FakeModelAlreadyGood)
+    unpatch_model_class_tool_use_id(FakeModelMissingNameForcedBad)
+
+
+# ----------------------------
+# Tests
+# ----------------------------
+
+@pytest.mark.asyncio
+async def test_rewrites_bad_tooluseid_and_keeps_consistent_for_delta_and_current_tool_use():
+    patch_model_class_tool_use_id(FakeModelBasicBad, id_factory=_list_id_factory(["fixed-1"]))
+
+    m = FakeModelBasicBad()
+    out = [ev async for ev in m.stream()]
+
+    start = out[0]["contentBlockStart"]["start"]["toolUse"]
+    delta = out[1]["contentBlockDelta"]["delta"]["toolUse"]
+    ctu = out[2]["current_tool_use"]
+
+    assert start["toolUseId"] == "fixed-1"
+    assert delta["toolUseId"] == "fixed-1"
+    assert ctu["toolUseId"] == "fixed-1"
+    assert start["name"] == "mytool"  # name preserved in normal case
+
+
+@pytest.mark.asyncio
+async def test_state_is_per_stream_call_new_id_each_time():
+    patch_model_class_tool_use_id(FakeModelBasicBad, id_factory=_list_id_factory(["fixed-1", "fixed-2"]))
+
+    m = FakeModelBasicBad()
+
+    out1 = [ev async for ev in m.stream()]
+    out2 = [ev async for ev in m.stream()]
+
+    id1 = out1[0]["contentBlockStart"]["start"]["toolUse"]["toolUseId"]
+    id2 = out2[0]["contentBlockStart"]["start"]["toolUse"]["toolUseId"]
+
+    assert id1 == "fixed-1"
+    assert id2 == "fixed-2"
+
+
+@pytest.mark.asyncio
+async def test_delta_with_no_name_and_no_id_is_not_rewritten():
+    patch_model_class_tool_use_id(FakeModelDeltaNoNameNoId, id_factory=_list_id_factory(["fixed-1"]))
+
+    m = FakeModelDeltaNoNameNoId()
+    out = [ev async for ev in m.stream()]
+
+    # Start got rewritten
+    start = out[0]["contentBlockStart"]["start"]["toolUse"]
+    assert start["toolUseId"] == "fixed-1"
+
+    # Delta should remain untouched because (name or tuid) is False
+    delta = out[1]["contentBlockDelta"]["delta"]["toolUse"]
+    assert delta["name"] is None
+    assert delta["toolUseId"] is None
+
+
+@pytest.mark.asyncio
+async def test_does_not_change_already_unique_tooluseid():
+    patch_model_class_tool_use_id(FakeModelAlreadyGood, id_factory=_list_id_factory(["fixed-1"]))
+
+    m = FakeModelAlreadyGood()
+    out = [ev async for ev in m.stream()]
+
+    tool_use = out[0]["contentBlockStart"]["start"]["toolUse"]
+    assert tool_use["toolUseId"] == "tooluse_abc123"
+
+
+@pytest.mark.asyncio
+async def test_missing_name_is_filled_with_old_tooluseid_when_forced_bad():
+    # Force the bad-id path when name is empty string, to cover:
+    #   if not name: tool_use["name"] = tuid
+    def force_bad_id(tool_use_id, tool_name) -> bool:
+        return not tool_name  # treat missing/empty name as bad
+
+    patch_model_class_tool_use_id(
+        FakeModelMissingNameForcedBad,
+        is_bad_id=force_bad_id,
+        id_factory=_list_id_factory(["fixed-1", "fixed-2"]),
+    )
+
+    m = FakeModelMissingNameForcedBad()
+    out = [ev async for ev in m.stream()]
+
+    start = out[0]["contentBlockStart"]["start"]["toolUse"]
+    ctu = out[1]["current_tool_use"]
+
+    # Start: name should be populated from the pre-rewrite toolUseId ("mytool")
+    assert start["name"] == "mytool"
+    assert start["toolUseId"] == "fixed-1"
+
+    # current_tool_use: name should be populated similarly, and toolUseId should reuse state ("fixed-1")
+    assert ctu["name"] == "mytool"
+    assert ctu["toolUseId"] == "fixed-1"
+
+
+def test_patch_is_idempotent():
+    patch_model_class_tool_use_id(FakeModelBasicBad, id_factory=_list_id_factory(["fixed-1"]))
+    patch_model_class_tool_use_id(FakeModelBasicBad, id_factory=_list_id_factory(["fixed-2"]))  # no-op
+
+
+@pytest.mark.asyncio
+async def test_unpatch_restores_original_stream_behavior():
+    patch_model_class_tool_use_id(FakeModelBasicBad, id_factory=_list_id_factory(["fixed-1"]))
+
+    m = FakeModelBasicBad()
+    patched_out = [ev async for ev in m.stream()]
+    assert patched_out[0]["contentBlockStart"]["start"]["toolUse"]["toolUseId"] == "fixed-1"
+
+    unpatch_model_class_tool_use_id(FakeModelBasicBad)
+
+    m2 = FakeModelBasicBad()
+    unpatched_out = [ev async for ev in m2.stream()]
+    assert unpatched_out[0]["contentBlockStart"]["start"]["toolUse"]["toolUseId"] == "mytool"
+
+
+def test_patch_raises_if_no_stream_method():
+    class NoStream:
+        pass
+
+    with pytest.raises(TypeError):
+        patch_model_class_tool_use_id(NoStream)
+
+
+def test_tooluseid_hook_registers_after_tool_call_callback():
+    hook = ToolUseIdHook()
+
+    calls = []
+
+    class RegistryStub:
+        def add_callback(self, event_type, callback):
+            calls.append((event_type, callback))
+
+    registry = RegistryStub()
+    hook.register_hooks(registry)
+
+    assert len(calls) == 1
+    event_type, callback = calls[0]
+
+    assert event_type is AfterToolCallEvent
+    # Bound method should be on this instance
+    assert getattr(callback, "__self__", None) is hook
+    assert getattr(callback, "__func__", None) is ToolUseIdHook.revert_tool_use_id
+
+
+def test_tooluseid_hook_reverts_tooluseid_and_result_when_generated_id_present():
+    hook = ToolUseIdHook()
+
+    class Event:
+        def __init__(self):
+            self.tool_use = {"name": "mem0_memory", "toolUseId": "tooluse_deadbeef"}
+            self.result = {"toolUseId": "tooluse_deadbeef", "ok": True}
+
+    ev = Event()
+    hook.revert_tool_use_id(ev)  # type: ignore[arg-type]
+
+    # tool_use reverted
+    assert ev.tool_use["toolUseId"] == "mem0_memory"
+    assert ev.tool_use["_toolUseId"] == "tooluse_deadbeef"
+
+    # result reverted
+    assert ev.result["toolUseId"] == "mem0_memory"
+    assert ev.result["_toolUseId"] == "tooluse_deadbeef"
+
+
+@pytest.mark.parametrize(
+    "tool_name,tool_use_id",
+    [
+        ("mem0_memory", "mem0_memory"),   # not generated
+        ("mem0_memory", ""),              # empty id
+        ("", "tooluse_deadbeef"),         # missing tool name => guard should prevent changes
+        ("mem0_memory", "abc123"),        # doesn't start with tooluse_
+    ],
+)
+def test_tooluseid_hook_noop_when_not_generated_or_missing_name(tool_name, tool_use_id):
+    hook = ToolUseIdHook()
+
+    class Event:
+        def __init__(self):
+            self.tool_use = {"name": tool_name, "toolUseId": tool_use_id}
+            self.result = {"toolUseId": tool_use_id, "ok": True}
+
+    ev = Event()
+    before_tool_use = dict(ev.tool_use)
+    before_result = dict(ev.result)
+
+    hook.revert_tool_use_id(ev)  # type: ignore[arg-type]
+
+    assert ev.tool_use == before_tool_use
+    assert ev.result == before_result
+
+
+def test_tooluseid_hook_ignores_non_dict_result():
+    hook = ToolUseIdHook()
+
+    class Event:
+        def __init__(self):
+            self.tool_use = {"name": "shell", "toolUseId": "tooluse_deadbeef"}
+            self.result = "not a dict"
+
+    ev = Event()
+    hook.revert_tool_use_id(ev)  # type: ignore[arg-type]
+
+    assert ev.tool_use["toolUseId"] == "shell"
+    assert ev.tool_use["_toolUseId"] == "tooluse_deadbeef"
+    assert ev.result == "not a dict"
+
+
+def test_tooluseid_hook_handles_event_without_tool_use_attr():
+    hook = ToolUseIdHook()
+
+    class Event:
+        def __init__(self):
+            self.result = {"toolUseId": "tooluse_deadbeef"}
+
+    ev = Event()
+    before_result = dict(ev.result)
+
+    hook.revert_tool_use_id(ev)  # type: ignore[arg-type]
+
+    # With no tool_use (and thus no tool_name), hook should do nothing.
+    assert ev.result == before_result

--- a/tests/test_context_utils.py
+++ b/tests/test_context_utils.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock
 from modules.config.manager import align_mem0_config
 from modules.config.models.factory import (
     _parse_context_window_fallbacks,
-    _split_model_prefix,
 )
+from modules.config.providers import split_litellm_model_id
 
 
 def test_parse_context_window_fallbacks_valid():
@@ -41,6 +41,18 @@ def testalign_mem0_config_sets_expected_provider():
 
 
 def test_split_model_prefix_handles_no_prefix():
-    prefix, remainder = _split_model_prefix("claude-3")
+    prefix, remainder = split_litellm_model_id("claude-3")
     assert prefix == ""
     assert remainder == "claude-3"
+
+
+def test_split_model_prefix_handles_prefix_variant():
+    prefix, remainder = split_litellm_model_id("openrouter/openai/gpt-oss-120b:free")
+    assert prefix == "openrouter"
+    assert remainder == "openai/gpt-oss-120b"
+
+
+def test_split_model_prefix_handles_prefix():
+    prefix, remainder = split_litellm_model_id("openrouter/openai/gpt-oss-120b")
+    assert prefix == "openrouter"
+    assert remainder == "openai/gpt-oss-120b"

--- a/tests/test_conversation_manager_integration.py
+++ b/tests/test_conversation_manager_integration.py
@@ -426,12 +426,12 @@ class TestSpecialistFlowIntegration:
             )
 
             # Specialist with swarm model (should get safe limit that accounts for overhead)
-            # Overhead = 8000 + 3000 + 50 = 11050 tokens just for system/tools/metadata
+            # Overhead = 8000 + 15000 + 50 = 23050 tokens just for system/tools/metadata
             # So safe limit must exceed overhead to allow any content
             specialist = AgentStub(
                 messages=[make_message("specialist task")],
                 model="azure/gpt-4o",
-                limit=20000  # Safe limit that accounts for overhead
+                limit=30000  # Safe limit that accounts for overhead
             )
 
             # Estimate tokens for specialist
@@ -935,10 +935,12 @@ class TestToolPairPreservation:
         # Apply management - should trigger pruning at boundary (>=, not >)
         manager.apply_management(agent)
 
-        # Verify pruning occurred (target is 90% = 9 messages)
-        assert len(agent.messages) < 10, (
-            f"Window overflow should trigger at boundary: expected <10, got {len(agent.messages)}"
-        )
+        # Verify pruning reached the clamped 90% target
+        assert len(agent.messages) == 9
+
+        # Sanity: first and last messages should remain
+        assert agent.messages[0]["content"][0]["text"] == "Message 0"
+        assert agent.messages[-1]["content"][0]["text"] == "Message 9"
 
 
 # ============================================================================

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from modules.tools.prompt_optimizer import PromptOptimizerError, prompt_optimizer
+from modules.tools.prompt_optimizer import (
+    PromptOptimizerError,
+    prompt_optimizer,
+    _extract_protected_blocks,
+    _llm_rewrite_execution_prompt,
+)
 
 
 def _setup_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -12,9 +17,59 @@ def _setup_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setenv("CYBER_OPERATION_ROOT", str(root))
     monkeypatch.setenv("CYBER_OPERATION_ID", "OP_TEST")
     monkeypatch.setenv("CYBER_TARGET_NAME", "target")
-    # Clear cooldown tracking to avoid cross-test interference
-    monkeypatch.delenv("CYBER_PROMPT_OVERLAY_LAST_STEP", raising=False)
     return root
+
+
+def _install_llm_rewrite_stubs(monkeypatch: pytest.MonkeyPatch, *, response_text: str, call_counter: dict) -> None:
+    """Patch config manager + strands Agent/model classes so _llm_rewrite_execution_prompt is deterministic."""
+    import types
+
+    class _DummyServerConfig:
+        llm = types.SimpleNamespace(model_id="dummy-model")
+
+    class _DummyConfigManager:
+        def get_provider(self) -> str:
+            return "ollama"
+
+        def get_server_config(self, provider: str):
+            return _DummyServerConfig()
+
+        def get_default_region(self) -> str:
+            return "us-east-1"
+
+        def get_local_model_config(self, model_id: str, provider: str):
+            return {
+                "host": "http://127.0.0.1:11434",
+                "model_id": "dummy-model",
+                "temperature": 0.0,
+                "timeout": 1,
+            }
+
+    class _DummyModel:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class _FakeAgent:
+        def __init__(self, model=None, system_prompt: str = ""):
+            self.model = model
+            self.system_prompt = system_prompt
+
+        def __call__(self, request: str):
+            call_counter["count"] = call_counter.get("count", 0) + 1
+            return response_text
+
+    # Patch config manager factory
+    import modules.config.manager as config_manager_mod
+
+    monkeypatch.setattr(config_manager_mod, "get_config_manager", lambda: _DummyConfigManager())
+
+    # Patch strands Agent + Ollama model class
+    import strands
+    import strands.models.ollama as ollama_mod
+
+    monkeypatch.setattr(strands, "Agent", _FakeAgent)
+    monkeypatch.setattr(ollama_mod, "OllamaModel", _DummyModel)
 
 
 def test_prompt_optimizer_apply_and_reset(tmp_path, monkeypatch):
@@ -41,6 +96,11 @@ def test_prompt_optimizer_apply_and_reset(tmp_path, monkeypatch):
     assert data["origin"] == "agent_reflection"
     assert data["expires_after_steps"] == 10
 
+    # Cooldown should be persisted and scoped to OP_TEST
+    assert data["cooldown"]["operation_id"] == "OP_TEST"
+    assert data["cooldown"]["last_step"] == 12
+    assert data["cooldown"]["cooldown_steps"] == 8
+
     reset_result = prompt_optimizer(action="reset")
     assert reset_result["status"] == "success"
     assert reset_result["overlay"] is None
@@ -53,6 +113,12 @@ def test_prompt_optimizer_cooldown_enforced(tmp_path, monkeypatch):
     prompt_optimizer(
         action="apply", overlay={"directives": ["initial"]}, current_step=5
     )
+
+    # Cooldown state should exist and be scoped to OP_TEST
+    overlay_path = Path(__import__("os").environ["CYBER_OPERATION_ROOT"]) / "adaptive_prompt.json"
+    data = json.loads(overlay_path.read_text(encoding="utf-8"))
+    assert data["cooldown"]["operation_id"] == "OP_TEST"
+    assert data["cooldown"]["last_step"] == 5
 
     with pytest.raises(PromptOptimizerError):
         prompt_optimizer(
@@ -200,3 +266,167 @@ def test_prompt_optimizer_optimize_execution_with_empty_lists_dev_backup(tmp_pat
     assert (root / "execution_prompt_optimized.txt.3").exists()
     assert not (root / "execution_prompt_optimized.txt.4").exists()
 
+
+def test_prompt_optimizer_quarantines_invalid_overlay_json(tmp_path, monkeypatch):
+    root = _setup_env(tmp_path, monkeypatch)
+
+    overlay_path = root / "adaptive_prompt.json"
+    overlay_path.write_text("{not valid json", encoding="utf-8")
+
+    view_result = prompt_optimizer(action="view")
+    assert view_result["status"] == "success"
+    assert view_result["overlay"] is None
+
+    # Corrupted overlay should be quarantined (moved aside)
+    assert not overlay_path.exists()
+    quarantined = sorted(root.glob("adaptive_prompt.json.corrupt.*"))
+    assert quarantined, "Expected corrupt overlay to be quarantined"
+
+
+def test_prompt_optimizer_quarantines_non_dict_overlay(tmp_path, monkeypatch):
+    root = _setup_env(tmp_path, monkeypatch)
+
+    overlay_path = root / "adaptive_prompt.json"
+    overlay_path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+    view_result = prompt_optimizer(action="view")
+    assert view_result["status"] == "success"
+    assert view_result["overlay"] is None
+
+    assert not overlay_path.exists()
+    quarantined = sorted(root.glob("adaptive_prompt.json.corrupt.*"))
+    assert quarantined, "Expected non-dict overlay to be quarantined"
+
+
+def test_prompt_optimizer_cooldown_scoped_by_operation_id(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+
+    prompt_optimizer(action="apply", overlay={"directives": ["initial"]}, current_step=5)
+
+    # Different operation_id should not be subject to the previous cooldown
+    monkeypatch.setenv("CYBER_OPERATION_ID", "OP_OTHER")
+    result = prompt_optimizer(
+        action="apply", overlay={"directives": ["new_op"]}, current_step=10
+    )
+    assert result["status"] == "success"
+
+
+def test_prompt_optimizer_cooldown_step_rollback_treated_as_reset(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+
+    prompt_optimizer(action="apply", overlay={"directives": ["initial"]}, current_step=50)
+
+    # If steps go backwards, cooldown should be treated as reset/new timeline
+    result = prompt_optimizer(
+        action="apply", overlay={"directives": ["rollback_ok"]}, current_step=10
+    )
+    assert result["status"] == "success"
+
+
+def test_extract_protected_blocks_round_trip():
+    text = "a\n<!-- PROTECTED -->\nKEEP\n<!-- /PROTECTED -->\nb\n"
+    blocks = _extract_protected_blocks(text)
+    assert blocks == ["<!-- PROTECTED -->\nKEEP\n<!-- /PROTECTED -->"]
+
+
+def test_llm_rewrite_rejects_line_growth(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    monkeypatch.setenv("CYBER_OPERATION_ID", "OP_LINE")
+
+    # Reset per-operation failure cache between tests
+    if hasattr(_llm_rewrite_execution_prompt, "_failure_counts"):
+        _llm_rewrite_execution_prompt._failure_counts.clear()
+
+    current_prompt = (
+            "L1 " + ("x" * 60) + "\n" +
+            "L2 " + ("y" * 60) + "\n" +
+            "L3 " + ("z" * 60)
+    )
+    # 4 lines -> should be rejected even if within ±15% chars
+    rewritten = current_prompt + "\nL4 extra"
+
+    calls = {"count": 0}
+    _install_llm_rewrite_stubs(monkeypatch, response_text=rewritten, call_counter=calls)
+
+    out = _llm_rewrite_execution_prompt(
+        current_prompt=current_prompt,
+        learned_patterns="evidence",
+        remove_tactics=[],
+        focus_tactics=[],
+    )
+    assert calls["count"] == 1
+    assert out == current_prompt
+
+
+def test_llm_rewrite_rejects_protected_block_modification(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+    monkeypatch.setenv("CYBER_OPERATION_ID", "OP_PROT")
+
+    if hasattr(_llm_rewrite_execution_prompt, "_failure_counts"):
+        _llm_rewrite_execution_prompt._failure_counts.clear()
+
+    current_prompt = (
+            "Intro " + ("a" * 40) + "\n"
+            "<!-- PROTECTED -->\n"
+            "KEEP_THIS\n"
+            "<!-- /PROTECTED -->\n"
+            "Outro " + ("b" * 40)
+    )
+
+    # Same number of lines, within bounds, but changes protected content
+    rewritten = current_prompt.replace("KEEP_THIS", "CHANGED")
+
+    calls = {"count": 0}
+    _install_llm_rewrite_stubs(monkeypatch, response_text=rewritten, call_counter=calls)
+
+    out = _llm_rewrite_execution_prompt(
+        current_prompt=current_prompt,
+        learned_patterns="evidence",
+        remove_tactics=[],
+        focus_tactics=[],
+    )
+    assert calls["count"] == 1
+    assert out == current_prompt
+
+
+def test_llm_rewrite_failure_count_scoped_per_operation(tmp_path, monkeypatch):
+    _setup_env(tmp_path, monkeypatch)
+
+    if hasattr(_llm_rewrite_execution_prompt, "_failure_counts"):
+        _llm_rewrite_execution_prompt._failure_counts.clear()
+
+    current_prompt = (
+            "L1 " + ("x" * 60) + "\n" +
+            "L2 " + ("y" * 60) + "\n" +
+            "L3 " + ("z" * 60)
+    )
+
+    # Force repeated failures by returning a line-growing rewrite
+    bad_rewrite = current_prompt + "\nL4"
+
+    calls = {"count": 0}
+    _install_llm_rewrite_stubs(monkeypatch, response_text=bad_rewrite, call_counter=calls)
+
+    monkeypatch.setenv("CYBER_OPERATION_ID", "OP_FAIL")
+    for _ in range(4):
+        out = _llm_rewrite_execution_prompt(
+            current_prompt=current_prompt,
+            learned_patterns="evidence",
+            remove_tactics=[],
+            focus_tactics=[],
+        )
+        assert out == current_prompt
+
+    # The 4th call should have short-circuited (no Agent call) due to 3 prior failures
+    assert calls["count"] == 3
+
+    # Different operation id should get its own failure budget
+    monkeypatch.setenv("CYBER_OPERATION_ID", "OP_FAIL_OTHER")
+    out2 = _llm_rewrite_execution_prompt(
+        current_prompt=current_prompt,
+        learned_patterns="evidence",
+        remove_tactics=[],
+        focus_tactics=[],
+    )
+    assert out2 == current_prompt
+    assert calls["count"] == 4

--- a/tests/test_swarm_tool.py
+++ b/tests/test_swarm_tool.py
@@ -19,6 +19,15 @@ class FakeSwarm:
         return FakeSwarm.result_to_return
 
 
+class _FakeAgent:
+    """Minimal stand-in for strands.Agent that captures init kwargs and allows setattr()."""
+    instances: list["_FakeAgent"] = []
+
+    def __init__(self, **kwargs):
+        self.init_kwargs = kwargs
+        _FakeAgent.instances.append(self)
+
+
 def _mk_result():
     # Shape matches what swarm() expects.
     content_a1 = [SimpleNamespace(text="A1 says hello.")]
@@ -41,6 +50,24 @@ class SwarmToolTests(unittest.TestCase):
         FakeSwarm.last_init_kwargs = None
         FakeSwarm.last_task = None
         FakeSwarm.result_to_return = None
+        _FakeAgent.instances = []
+
+    def _mk_parent_agent(self, *, prompt_token_limit=None):
+        return SimpleNamespace(
+            system_prompt="PARENT_SYSTEM_PROMPT",
+            callback_handler=object(),
+            conversation_manager=object(),
+            load_tools_from_directory=False,
+            swarm_hooks=[],
+            trace_attributes={},  # must support dict union (|)
+            tool_registry=SimpleNamespace(
+                registry={
+                    # tool objects should have tool_name for trace attributes
+                    "shell": SimpleNamespace(tool_name="shell"),
+                }
+            ),
+            _prompt_token_limit=prompt_token_limit,
+        )
 
     def test_swarm_returns_error_when_agents_missing(self):
         out = swarm_mod.swarm(task="x", agents=[])
@@ -198,3 +225,169 @@ class SwarmToolTests(unittest.TestCase):
 
         self.assertEqual("error", out["status"])
         self.assertIn("Custom swarm execution failed: kaboom", out["content"][0]["text"])
+
+    def test_create_custom_agents_inherits_prompt_token_limit_from_parent_when_truthy(self):
+        parent = self._mk_parent_agent(prompt_token_limit=123)
+
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                patch.object(swarm_mod, "get_capabilities", autospec=True,
+                             return_value=SimpleNamespace(supports_reasoning=False)), \
+                patch.object(swarm_mod, "Agent", new=_FakeAgent):
+            agents = swarm_mod._create_custom_agents(
+                [{"name": "agent1", "tools": ["shell"]}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(1, len(agents))
+        a = agents[0]
+        self.assertTrue(hasattr(a, "_prompt_token_limit"))
+        self.assertEqual(123, getattr(a, "_prompt_token_limit"))
+
+    def test_create_custom_agents_does_not_inherit_prompt_token_limit_from_parent_when_falsy(self):
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        for falsy in (0, None):
+            _FakeAgent.instances = []
+            parent = self._mk_parent_agent(prompt_token_limit=falsy)
+
+            with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                    patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                    patch.object(swarm_mod, "get_capabilities", autospec=True,
+                                 return_value=SimpleNamespace(supports_reasoning=False)), \
+                    patch.object(swarm_mod, "Agent", new=_FakeAgent):
+                agents = swarm_mod._create_custom_agents(
+                    [{"name": "agent1", "tools": ["shell"]}],
+                    parent_agent=parent,
+                )
+
+            self.assertEqual(1, len(agents))
+            a = agents[0]
+            self.assertFalse(hasattr(a, "_prompt_token_limit"), f"should not set for falsy={falsy!r}")
+
+    def test_create_custom_agents_sets_prompt_token_limit_from_resolver_when_truthy(self):
+        parent = self._mk_parent_agent(prompt_token_limit=123)  # should be ignored
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                patch.object(swarm_mod, "get_capabilities", autospec=True,
+                             return_value=SimpleNamespace(supports_reasoning=False)), \
+                patch.object(swarm_mod, "_resolve_prompt_token_limit", autospec=True, return_value=456), \
+                patch.object(swarm_mod, "Agent", new=_FakeAgent):
+            agents = swarm_mod._create_custom_agents(
+                [{"name": "agent1", "tools": ["shell"]}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(1, len(agents))
+        a = agents[0]
+        self.assertTrue(hasattr(a, "_prompt_token_limit"))
+        self.assertEqual(456, getattr(a, "_prompt_token_limit"))
+
+    def test_create_custom_agents_inherits_prompt_token_limit_from_parent_when_resolver_falsy(self):
+        parent = self._mk_parent_agent(prompt_token_limit=123)
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                patch.object(swarm_mod, "get_capabilities", autospec=True,
+                             return_value=SimpleNamespace(supports_reasoning=False)), \
+                patch.object(swarm_mod, "_resolve_prompt_token_limit", autospec=True, return_value=None), \
+                patch.object(swarm_mod, "Agent", new=_FakeAgent):
+            agents = swarm_mod._create_custom_agents(
+                [{"name": "agent1", "tools": ["shell"]}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(1, len(agents))
+        a = agents[0]
+        self.assertTrue(hasattr(a, "_prompt_token_limit"))
+        self.assertEqual(123, getattr(a, "_prompt_token_limit"))
+
+    def test_create_custom_agents_does_not_set_prompt_token_limit_when_resolver_falsy_and_parent_falsy(self):
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        for falsy_parent in (0, None):
+            _FakeAgent.instances = []
+            parent = self._mk_parent_agent(prompt_token_limit=falsy_parent)
+
+            with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                    patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                    patch.object(swarm_mod, "get_capabilities", autospec=True,
+                                 return_value=SimpleNamespace(supports_reasoning=False)), \
+                    patch.object(swarm_mod, "_resolve_prompt_token_limit", autospec=True, return_value=0), \
+                    patch.object(swarm_mod, "Agent", new=_FakeAgent):
+                agents = swarm_mod._create_custom_agents(
+                    [{"name": "agent1", "tools": ["shell"]}],
+                    parent_agent=parent,
+                )
+
+            self.assertEqual(1, len(agents))
+            a = agents[0]
+            self.assertFalse(
+                hasattr(a, "_prompt_token_limit"),
+                f"should not set when resolver and parent are falsy (parent={falsy_parent!r})",
+            )
+
+    def test_create_custom_agents_sets_allow_reasoning_content_true_when_capabilities_support(self):
+        parent = self._mk_parent_agent(prompt_token_limit=10)
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                patch.object(swarm_mod, "get_capabilities", autospec=True,
+                             return_value=SimpleNamespace(supports_reasoning=True)), \
+                patch.object(swarm_mod, "_resolve_prompt_token_limit", autospec=True, return_value=None), \
+                patch.object(swarm_mod, "Agent", new=_FakeAgent):
+            agents = swarm_mod._create_custom_agents(
+                [{"name": "agent1", "tools": ["shell"]}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(1, len(agents))
+        a = agents[0]
+        self.assertTrue(hasattr(a, "_allow_reasoning_content"))
+        self.assertEqual(True, getattr(a, "_allow_reasoning_content"))
+
+    def test_create_custom_agents_sets_allow_reasoning_content_false_on_capabilities_error(self):
+        parent = self._mk_parent_agent(prompt_token_limit=10)
+        cfg = SimpleNamespace(
+            get_provider=lambda: "prov",
+            get_swarm_model_id=lambda _provider: "swarm-model",
+        )
+
+        with patch.object(swarm_mod, "get_config_manager", autospec=True, return_value=cfg), \
+                patch.object(swarm_mod, "create_strands_model", autospec=True, return_value=object()), \
+                patch.object(swarm_mod, "get_capabilities", autospec=True, side_effect=RuntimeError("caps fail")), \
+                patch.object(swarm_mod, "_resolve_prompt_token_limit", autospec=True, return_value=None), \
+                patch.object(swarm_mod, "Agent", new=_FakeAgent):
+            agents = swarm_mod._create_custom_agents(
+                [{"name": "agent1", "tools": ["shell"]}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(1, len(agents))
+        a = agents[0]
+        self.assertTrue(hasattr(a, "_allow_reasoning_content"))
+        self.assertEqual(False, getattr(a, "_allow_reasoning_content"))

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "boto3", specifier = ">=1.42.4" },
     { name = "botocore", specifier = ">=1.42.4" },
-    { name = "ddgs", specifier = "~=9.6.1" },
+    { name = "ddgs", specifier = "~=9.10.0" },
     { name = "faiss-cpu" },
     { name = "flake8", marker = "extra == 'dev'" },
     { name = "google-genai", specifier = ">=1.49.0" },
@@ -1034,17 +1034,18 @@ wheels = [
 
 [[package]]
 name = "ddgs"
-version = "9.6.1"
+version = "9.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "fake-useragent" },
     { name = "httpx", extra = ["brotli", "http2", "socks"] },
     { name = "lxml" },
     { name = "primp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/a3/f2ad1a105d0de9b77a78712cfca592c19a0ee8ca9a02970d8864a8d756d2/ddgs-9.6.1.tar.gz", hash = "sha256:15ec3aace0417c0ab3c0184059e1e03dbd6bda8d3be6108949c18ad7b4cd1e11", size = 35881, upload-time = "2025-10-12T18:36:33.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/76/8dc0323d1577037abad7a679f8af150ebb73a94995d3012de71a8898e6e6/ddgs-9.10.0.tar.gz", hash = "sha256:d9381ff75bdf1ad6691d3d1dc2be12be190d1d32ecd24f1002c492143c52c34f", size = 31491, upload-time = "2025-12-17T23:30:15.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/58/4b35f13d21a44681e71ee8b1bca5755db0f84017cb29593eb0375aaa01e0/ddgs-9.6.1-py3-none-any.whl", hash = "sha256:e7d7e0c4dbae3f287627b9f6e411278256d7859d017bbad45b8229c230bf5270", size = 41577, upload-time = "2025-10-12T18:36:32.505Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/0e/d4b7d6a8df5074cf67bc14adead39955b0bf847c947ff6cad0bb527887f4/ddgs-9.10.0-py3-none-any.whl", hash = "sha256:81233d79309836eb03e7df2a0d2697adc83c47c342713132c0ba618f1f2c6eee", size = 40311, upload-time = "2025-12-17T23:30:13.606Z" },
 ]
 
 [[package]]
@@ -1121,6 +1122,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/3a/bbdf5deaf6feb34b46b469c0a0acd40216c3d3c6ecf5aeb71d56b8a650e3/faiss_cpu-1.13.2-cp312-cp312-win_arm64.whl", hash = "sha256:2c4f696ae76e7c97cbc12311db83aaf1e7f4f7be06a3ffea7e5b0e8ec1fd805b", size = 8553157, upload-time = "2025-12-24T10:27:26.38Z" },
     { url = "https://files.pythonhosted.org/packages/60/4b/903d85bf3a8264d49964ec799e45c7ffc91098606b8bc9ef2c904c1a56cb/faiss_cpu-1.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:cb4b5ee184816a4b099162ac93c0d7f0033d81a88e7c1291d0a9cc41ec348984", size = 18891330, upload-time = "2025-12-24T10:27:28.806Z" },
     { url = "https://files.pythonhosted.org/packages/b2/52/5d10642da628f63544aab27e48416be4a7ea25c6b81d8bd65016d8538b00/faiss_cpu-1.13.2-cp313-cp313-win_arm64.whl", hash = "sha256:1243967eeb2298791ff7f3683a4abd2100d7e6ec7542ca05c3b75d47a7f621e5", size = 8553088, upload-time = "2025-12-24T10:27:31.325Z" },
+]
+
+[[package]]
+name = "fake-useragent"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/43/948d10bf42735709edb5ae51e23297d034086f17fc7279fef385a7acb473/fake_useragent-2.2.0.tar.gz", hash = "sha256:4e6ab6571e40cc086d788523cf9e018f618d07f9050f822ff409a4dfe17c16b2", size = 158898, upload-time = "2025-04-14T15:32:19.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/37/b3ea9cd5558ff4cb51957caca2193981c6b0ff30bd0d2630ac62505d99d0/fake_useragent-2.2.0-py3-none-any.whl", hash = "sha256:67f35ca4d847b0d298187443aaf020413746e56acd985a611908c73dba2daa24", size = 161695, upload-time = "2025-04-14T15:32:17.732Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Fixes based on code review.

* Fixes for memory, conversation compression, prompt optimizer.

* Fix for toolUseId, which caused incorrect detection of no-progress. Fix getting model info for :free models.

* Improve fix for toolUseId, prevent models from thinking ID is a tool name.

* Update tool overhead tokens

* swarm agents get correct prompt token limit and "apply reasoning" setting.

* Fix logic when logging tool router warning

* Add reference to double16/validation-benchmarks.git