### PR TITLE
Sundry fixes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM cyber-autoagent-tools:latest
 
 LABEL org.opencontainers.image.title="Cyber-AutoAgent"
 LABEL org.opencontainers.image.description="Autonomous AI agent for ethical security assessments"
-LABEL org.opencontainers.image.version="0.4.0"
+LABEL org.opencontainers.image.version="0.4.1"
 LABEL org.opencontainers.image.source="https://github.com/double16/cyber-autoagent"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -22,7 +22,7 @@ FROM kalilinux/kali-rolling
 
 LABEL org.opencontainers.image.title="Cyber-AutoAgent Tools"
 LABEL org.opencontainers.image.description="Autonomous AI agent for ethical security assessments"
-LABEL org.opencontainers.image.version="0.4.0"
+LABEL org.opencontainers.image.version="0.4.1"
 LABEL org.opencontainers.image.source="https://github.com/double16/cyber-autoagent"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/docs/user-instructions.md
+++ b/docs/user-instructions.md
@@ -287,7 +287,7 @@ can be used to configure, command line options or environment variables.
          "server_url": "https://127.0.0.1:8000/mcp",
          "plugins": ["*"], 
          "timeoutSeconds": 900,
-         "allowed_tools": ["port_scan","register_hostname_address","directory_buster","deobfuscate_javascript","fetch_web_resource_content","find_domains","find_hosts","find_netloc","find_urls","find_web_resources","spider_website","index_http_url","query_findings","web_search","unavailable"]  // or ["*"]
+         "allowed_tools": ["port_scan","register_hostname_address","register_http_headers","directory_buster","deobfuscate_javascript","fetch_web_resource_content","find_domains","find_hosts","find_netloc","find_urls","find_web_resources","spider_website","index_http_url","query_findings"]  // or ["*"]
       }
     ]
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "caa"
-version = "0.4.0"
+version = "0.4.1"
 description = "Cyber-AutoAgent: Autonomous AI agent for ethical security assessments"
 readme = "README.md"
 authors = [

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,7 +2,7 @@
 Cyber-AutoAgent - Autonomous Cybersecurity Assessment Tool
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Patrick Double"
 __credits__ = ["Aaron Brown (original author)"]
 __license__ = "MIT"

--- a/src/modules/__init__.py
+++ b/src/modules/__init__.py
@@ -1,6 +1,6 @@
 """Cyber-AutoAgent modules package."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __author__ = "Patrick Double"
 __credits__ = ["Aaron Brown (original author)"]
 __license__ = "MIT"

--- a/src/modules/agents/cyber_autoagent.py
+++ b/src/modules/agents/cyber_autoagent.py
@@ -513,6 +513,8 @@ Guidance and tool names in prompts are illustrative, not prescriptive. Always ch
         load_tool,
         mem0_memory,
         stop,
+        sleep,
+        python_repl,
     ]
 
     if enable_prompt_optimization:
@@ -871,7 +873,7 @@ Guidance and tool names in prompts are illustrative, not prescriptive. Always ch
         )
         hooks.append(prompt_rebuild_hook)
 
-    model = create_strands_model(config.provider, config.model_id)
+    model = create_strands_model(config.provider, config.model_id, "primary")
 
     agent_logger.debug("Creating autonomous agent")
 

--- a/src/modules/config/manager.py
+++ b/src/modules/config/manager.py
@@ -17,6 +17,7 @@ Key Components:
 
 import json
 import os
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 import litellm
@@ -928,6 +929,7 @@ class ConfigManager:
         """Get evaluation embedding configuration."""
         return defaults["embedding"]
 
+    @lru_cache
     def get_safe_max_tokens(self, model_id: str, buffer: float = 0.5) -> int:
         """Get safe max_tokens using models.dev (50% of limit by default).
 
@@ -976,7 +978,7 @@ class ConfigManager:
 
     def _get_swarm_llm_config(
         self, _server: str, defaults: Dict[str, Any]
-    ) -> ModelConfig:
+    ) -> LLMConfig:
         """Get swarm LLM configuration with model-aware token limits."""
         swarm_cfg = defaults["swarm_llm"]
 
@@ -1113,6 +1115,7 @@ class ConfigManager:
             operation_id=operation_id,
         )
 
+    @lru_cache
     def get_rate_limit_config(self, provider: Optional[str] = None) -> Optional[RateLimitConfig]:
         request_per_minute = self.getenv_float("CYBER_RATE_LIMIT_REQ_PER_MIN")
         tokens_per_minute = self.getenv_float("CYBER_RATE_LIMIT_TOKENS_PER_MIN")
@@ -1136,8 +1139,6 @@ class ConfigManager:
             )
 
         return None
-
-    # Validation helper methods now in validation.py module
 
 
 # Memory utility functions

--- a/src/modules/config/models/capabilities.py
+++ b/src/modules/config/models/capabilities.py
@@ -404,6 +404,7 @@ MODEL_FAMILY_PATTERNS = [
 ]
 
 
+@lru_cache
 def get_model_input_limit(model_id: str) -> Optional[int]:
     """Get INPUT token limit for a model (context window capacity).
 
@@ -448,6 +449,7 @@ def get_provider_default_limit(provider: str) -> Optional[int]:
     return defaults.get((provider or "").lower())
 
 
+@lru_cache
 def get_model_output_limit(model_id: str) -> Optional[int]:
     """Get OUTPUT token limit for a model (max completion length).
 
@@ -489,6 +491,7 @@ def get_model_output_limit(model_id: str) -> Optional[int]:
     return None
 
 
+@lru_cache
 def get_model_pricing(model_id: str) -> Optional[tuple[float, float]]:
     """Get pricing for a model (cost per million tokens).
 
@@ -504,7 +507,7 @@ def get_model_pricing(model_id: str) -> Optional[tuple[float, float]]:
             client = get_models_client()
             info = client.get_model_info(model_id)
             if info and info.pricing:
-                return (info.pricing.input, info.pricing.output)
+                return info.pricing.input, info.pricing.output
         except Exception:
             pass
 

--- a/src/modules/config/models/dev_client.py
+++ b/src/modules/config/models/dev_client.py
@@ -37,6 +37,7 @@ import json
 import logging
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -171,6 +172,7 @@ class ModelsDevClient:
         self._data: Optional[Dict] = None
         self._data_source: Optional[str] = None
 
+    @lru_cache
     def get_model_info(self, model_id: str) -> Optional[ModelInfo]:
         """Get complete model information.
 
@@ -205,6 +207,7 @@ class ModelsDevClient:
         logger.debug(f"Model not found: {model_id}")
         return None
 
+    @lru_cache
     def get_limits(self, model_id: str) -> Optional[ModelLimits]:
         """Get model token limits.
 
@@ -217,6 +220,7 @@ class ModelsDevClient:
         info = self.get_model_info(model_id)
         return info.limits if info else None
 
+    @lru_cache
     def get_capabilities(self, model_id: str) -> Optional[ModelCapabilities]:
         """Get model capabilities and features.
 
@@ -229,6 +233,7 @@ class ModelsDevClient:
         info = self.get_model_info(model_id)
         return info.capabilities if info else None
 
+    @lru_cache
     def get_pricing(self, model_id: str) -> Optional[ModelPricing]:
         """Get model pricing information.
 

--- a/src/modules/config/system/__init__.py
+++ b/src/modules/config/system/__init__.py
@@ -7,7 +7,7 @@ from modules.config.system.environment import (
 )
 from modules.config.system.env_reader import EnvironmentReader
 from modules.config.system.logger import configure_sdk_logging, get_logger
-from modules.config.system.defaults import build_default_configs
+from modules.config.system.defaults import build_default_configs, LLMRoleType
 from modules.config.system.validation import validate_provider
 
 __all__ = [
@@ -22,6 +22,7 @@ __all__ = [
     "get_logger",
     # Defaults
     "build_default_configs",
+    "LLMRoleType",
     # Validation
     "validate_provider",
 ]

--- a/src/modules/config/system/defaults.py
+++ b/src/modules/config/system/defaults.py
@@ -6,7 +6,7 @@ This module provides default configurations for LLM models, embeddings,
 and provider-specific settings across Bedrock, Ollama, and LiteLLM.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 from modules.config.types import (
     EmbeddingConfig,
@@ -14,6 +14,8 @@ from modules.config.types import (
     MemoryLLMConfig,
     ModelProvider,
 )
+
+LLMRoleType = Literal["primary", "swarm", "report", "evaluation", "unknown"]
 
 
 def build_default_configs() -> Dict[str, Dict[str, Any]]:

--- a/src/modules/config/types.py
+++ b/src/modules/config/types.py
@@ -235,7 +235,7 @@ class EvaluationConfig:
 class SwarmConfig:
     """Configuration for swarm system."""
 
-    llm: ModelConfig
+    llm: LLMConfig
 
 
 @dataclass

--- a/src/modules/handlers/react/hooks.py
+++ b/src/modules/handlers/react/hooks.py
@@ -76,7 +76,7 @@ class ReactHooks(HookProvider):
         try:
             tool_use = event.tool_use
             tool_name = tool_use.get("name", "unknown")
-            tool_id = tool_use.get("toolUseId", tool_use.get("id", "unknown"))
+            tool_id = tool_use.get("_toolUseId", tool_use.get("toolUseId", tool_use.get("id", "unknown")))
 
             # Enhanced logging for swarm debugging
             if tool_name == "swarm":
@@ -101,8 +101,6 @@ class ReactHooks(HookProvider):
                 command = tool_input["command"]
                 if isinstance(command, str) and command.strip().startswith("["):
                     try:
-                        import json
-
                         parsed_commands = json.loads(command)
                         if isinstance(parsed_commands, list):
                             tool_input["command"] = parsed_commands
@@ -156,7 +154,7 @@ class ReactHooks(HookProvider):
         try:
             tool_use = event.tool_use
             tool_name = tool_use.get("name", "unknown")
-            tool_id = tool_use.get("toolUseId", tool_use.get("id"))
+            tool_id = tool_use.get("_toolUseId", tool_use.get("toolUseId", tool_use.get("id", "unknown")))
 
             # Enhanced logging for swarm completion
             if tool_name == "swarm":

--- a/src/modules/interfaces/react/package.json
+++ b/src/modules/interfaces/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyber-autoagent-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Cyber-AutoAgent CLI with React + Ink",
   "type": "module",
   "main": "dist/index.js",

--- a/src/modules/interfaces/react/src/components/ErrorBoundary.tsx
+++ b/src/modules/interfaces/react/src/components/ErrorBoundary.tsx
@@ -81,7 +81,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <Box flexDirection="column" width="100%">
           {/* Always show header for visual continuity */}
           <Header
-            version="0.4.0"
+            version="0.4.1"
             terminalWidth={80}
             nightly={false}
           />

--- a/src/modules/interfaces/react/src/components/Header.tsx
+++ b/src/modules/interfaces/react/src/components/Header.tsx
@@ -30,7 +30,7 @@ const compactLogo = `🔐 Cyber-AutoAgent`;
 const ultraCompactLogo = `🔐 CAA`;
 
 export const Header: React.FC<HeaderProps> = React.memo(({
-  version ="0.4.0",
+  version ="0.4.1",
   terminalWidth = 80,
   nightly = false,
   exitNotice = false

--- a/src/modules/interfaces/react/src/components/MainAppView.tsx
+++ b/src/modules/interfaces/react/src/components/MainAppView.tsx
@@ -195,7 +195,7 @@ export const MainAppView: React.FC<MainAppViewProps> = ({
               <Box key={item}>
                 <Header
                   key={`app-header-${staticKey}`}
-                  version="0.4.0"
+                  version="0.4.1"
                   terminalWidth={appState.terminalDisplayWidth}
                   nightly={false}
                   exitNotice={Boolean((appState as any).exitNotice)}
@@ -207,7 +207,7 @@ export const MainAppView: React.FC<MainAppViewProps> = ({
           <Box>
             <Header
               key={`app-header-${staticKey}`}
-              version="0.4.0"
+              version="0.4.1"
               terminalWidth={appState.terminalDisplayWidth}
               nightly={false}
               exitNotice={Boolean((appState as any).exitNotice)}

--- a/src/modules/operation_plugins/web/tools/validation_specialist.py
+++ b/src/modules/operation_plugins/web/tools/validation_specialist.py
@@ -5,6 +5,7 @@ import logging
 
 from strands import Agent, tool
 from modules.config.models.factory import create_strands_model
+from modules.agents.patches import ToolUseIdHook
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def _create_specialist_model():
     swarm_model_id = config_manager.get_swarm_model_id()
 
     try:
-        return create_strands_model(provider, swarm_model_id)
+        return create_strands_model(provider, swarm_model_id, "swarm")
     except Exception as exc:  # fall back to main LLM if swarm override is misconfigured
         primary_model = config_manager.get_llm_config(provider).model_id
         logger.warning(
@@ -117,7 +118,7 @@ def _create_specialist_model():
             exc,
             primary_model,
         )
-        return create_strands_model(provider, primary_model)
+        return create_strands_model(provider, primary_model, "swarm")
 
 
 
@@ -135,7 +136,7 @@ def validation_specialist(
             model=_create_specialist_model(),
             system_prompt=VALIDATION_METHODOLOGY,
             tools=[editor, shell],
-            
+            hooks=[ToolUseIdHook()],
         )
 
         task = f"""Validate security finding:

--- a/src/modules/tools/browser.py
+++ b/src/modules/tools/browser.py
@@ -1536,9 +1536,10 @@ async def browser_observe_page(instruction: Optional[str] = None) -> list[str]:
 
 
 def log_heap_stats():
-    try:
-        from guppy import hpy
-        h = hpy()
-        logger.info(h.heap()[0:12])
-    except ImportError:
-        logger.debug("Install guppy3 for heap analysis")
+    if logger.isEnabledFor(logging.DEBUG):
+        try:
+            from guppy import hpy
+            h = hpy()
+            logger.debug(h.heap()[0:12])
+        except ImportError:
+            logger.debug("Install guppy3 for heap analysis")

--- a/src/modules/tools/web_search.py
+++ b/src/modules/tools/web_search.py
@@ -14,10 +14,10 @@ class WebSearchHit(BaseModel):
     snippet: str = Field(description="Result snippet")
 
 
-# 9.5.1 has backend: bing, brave, google, mojeek, mullvad_brave, mullvad_google, wikipedia, yahoo, yandex
+# 9.10.0 has backend: brave, duckduckgo, google, grokipedia, mojeek, wikipedia, yahoo, yandex
 def search_duckduckgo(query: str, num: int) -> List[WebSearchHit]:
     with DDGS() as ddg:
-        results = ddg.text(query, backend="brave,bing,google", max_results=num)
+        results = ddg.text(query, backend="brave,duckduckgo", max_results=num)
         return [WebSearchHit(title=r["title"], url=r["href"], snippet=r["body"])
                 for r in results]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from modules.config.models.capabilities import (
+    get_model_input_limit,
+    get_model_output_limit,
+    get_model_pricing,
+)
+
 # Disable dotenv loading in tests
 os.environ["PYTHON_DOTENV_DISABLED"] = "true"
 
@@ -19,9 +25,21 @@ for _var in (
     "CYBER_AGENT_PROVIDER",
     "CYBER_AGENT_LLM_MODEL",
     "CYBER_AGENT_EMBEDDING_MODEL",
+    "CYBER_AGENT_SWARM_MODEL",
+    "CYBER_AGENT_EVALUATION_MODEL",
+    "RAGAS_EVALUATOR_MODEL",
+    "CYBER_CONTEXT_LIMIT",
+    "CYBER_REASONING_ALLOW",
+    "CYBER_REASONING_DENY",
+    "CYBER_RATE_LIMIT_TOKENS_PER_MIN",
+    "CYBER_RATE_LIMIT_REQ_PER_MIN",
+    "CYBER_RATE_LIMIT_MAX_CONCURRENT",
     "AZURE_API_BASE",
     "AZURE_API_KEY",
     "AZURE_API_VERSION",
+    "OLLAMA_HOST",
+    "MAX_COMPLETION_TOKENS",
+    "MAX_TOKENS",
 ):
     os.environ.pop(_var, None)
 
@@ -179,3 +197,17 @@ def caplog_with_level():
         return _pytest.logging.LogCaptureFixture(pytest_config=None)
 
     return _caplog_with_level
+
+
+@pytest.fixture
+def clear_lru_caches():
+    fns = [
+        get_model_input_limit,
+        get_model_output_limit,
+        get_model_pricing,
+    ]
+    for fn in fns:
+        fn.cache_clear()
+    yield
+    for fn in fns:
+        fn.cache_clear()

--- a/tests/test_capabilities_precedence.py
+++ b/tests/test_capabilities_precedence.py
@@ -1,7 +1,6 @@
 """Test unified precedence order for model capabilities."""
 
 import os
-import pytest
 
 from modules.config.models.capabilities import (
     get_capabilities,
@@ -80,6 +79,7 @@ class TestTokenLimitPrecedence:
         """Verify MAX_COMPLETION_TOKENS (UI reasoning models) overrides models.dev."""
         os.environ["MAX_COMPLETION_TOKENS"] = "50000"
 
+        get_model_output_limit.cache_clear()
         limit = get_model_output_limit("azure/gpt-5")
         assert limit == 50000, "MAX_COMPLETION_TOKENS should override models.dev"
 
@@ -89,6 +89,7 @@ class TestTokenLimitPrecedence:
         """Verify MAX_TOKENS (UI general setting) overrides models.dev."""
         os.environ["MAX_TOKENS"] = "60000"
 
+        get_model_output_limit.cache_clear()
         limit = get_model_output_limit("azure/gpt-5")
         assert limit == 60000, "MAX_TOKENS should override models.dev"
 
@@ -99,11 +100,13 @@ class TestTokenLimitPrecedence:
         os.environ["MAX_COMPLETION_TOKENS"] = "50000"
         os.environ["MAX_TOKENS"] = "60000"
 
+        get_model_output_limit.cache_clear()
         limit = get_model_output_limit("azure/gpt-5")
         assert limit == 50000, "MAX_COMPLETION_TOKENS should have highest precedence"
 
         del os.environ["MAX_COMPLETION_TOKENS"]
 
+        get_model_output_limit.cache_clear()
         limit = get_model_output_limit("azure/gpt-5")
         assert limit == 60000, "MAX_TOKENS should be second priority"
 

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -51,9 +51,10 @@ def _install_llm_rewrite_stubs(monkeypatch: pytest.MonkeyPatch, *, response_text
             self.kwargs = kwargs
 
     class _FakeAgent:
-        def __init__(self, model=None, system_prompt: str = ""):
+        def __init__(self, model=None, system_prompt: str = "", hooks: list | None= None):
             self.model = model
             self.system_prompt = system_prompt
+            self.hooks = hooks
 
         def __call__(self, request: str):
             call_counter["count"] = call_counter.get("count", 0) + 1


### PR DESCRIPTION
- add back erroneously removed `python_repl` and `sleep` tools
- fix incorrect model parameters (i.e., max output tokens) when swarm model == main model
- validate swarm agent model and fall back to primary model
- fix broken tool calling (ollama, gemini) in report, validation_specialist agents
- relax prompt optimizer validation for line count increase
- minor efficiency updates
