### PR TITLE
feat: replace semgrep with opengrep

### DIFF
--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -286,7 +286,13 @@ RUN pipx install --global bloodhound && \
     pipx install --global coercer && \
     pipx install --global ropgadget && \
     pipx install --global ropper && \
-    pipx install --global semgrep && \
+    # Install opengrep (fork of semgrep with more features)
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then OPENGREP_ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then OPENGREP_ARCH="aarch64"; else OPENGREP_ARCH="x86_64"; fi && \
+    OPENGREP_VERSION=$(curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep "tag_name" | cut -d ":" -f 2 | tr -d " ,\"") && \
+    curl -L "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep-${OPENGREP_VERSION}-${OPENGREP_ARCH}-unknown-linux-musl.tar.gz" -o /tmp/opengrep.tar.gz && \
+    tar -xzf /tmp/opengrep.tar.gz -C /usr/local/bin/ --strip-components=1 && \
+    rm /tmp/opengrep.tar.gz && \
     # GraphQL Clairvoyance - GraphQL schema enumeration
     pipx install --global clairvoyance && \
     pipx install --global xsstrike && \

--- a/src/modules/config/system/environment.yaml
+++ b/src/modules/config/system/environment.yaml
@@ -202,11 +202,11 @@ cyber_tools:
     preference: preferred
     caps: [web_crawling, web_recon]
     canary: "katana -h"
-  semgrep:
+  opengrep:
     description: "Static source code analysis"
     preference: preferred
     caps: [sast]
-    canary: "semgrep -h"
+    canary: "opengrep -h"
 
   # DNS/Recon
   dnsrecon:


### PR DESCRIPTION
## Summary

Replaces semgrep with opengrep, a fork with more features, as requested in #147.

## Changes

### Dockerfile.tools
- Replaced `pipx install semgrep` with opengrep binary download from GitHub releases
- Added architecture detection (x86_64 / aarch64)
- Uses GitHub API to fetch latest release version dynamically
- Downloads and extracts opengrep binary to `/usr/local/bin/`

### environment.yaml
- Updated tool name from `semgrep` to `opengrep`
- Updated canary command from `semgrep -h` to `opengrep -h`
- Maintained same description, preference, and capabilities

## Testing

The implementation:
- Detects system architecture automatically
- Falls back to x86_64 if architecture is unknown
- Uses musl-linked binary for maximum compatibility
- Fetches latest release version from GitHub API

Closes #147