### PR TITLE
fix: use correct opengrep filename format (x86 not x86_64)

### DIFF
--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -290,7 +290,7 @@ RUN pipx install --global bloodhound && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then OPENGREP_ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then OPENGREP_ARCH="aarch64"; else OPENGREP_ARCH="x86_64"; fi && \
     OPENGREP_VERSION=$(curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep "tag_name" | cut -d ":" -f 2 | tr -d " ,\"") && \
-    curl -L "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep-${OPENGREP_VERSION}-${OPENGREP_ARCH}-unknown-linux-musl.tar.gz" -o /tmp/opengrep.tar.gz && \
+    curl -L "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep-core_linux_${OPENGREP_ARCH}.tar.gz" -o /tmp/opengrep.tar.gz && \
     tar -xzf /tmp/opengrep.tar.gz -C /usr/local/bin/ --strip-components=1 && \
     rm /tmp/opengrep.tar.gz && \
     # GraphQL Clairvoyance - GraphQL schema enumeration

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -286,7 +286,13 @@ RUN pipx install --global bloodhound && \
     pipx install --global coercer && \
     pipx install --global ropgadget && \
     pipx install --global ropper && \
-    pipx install --global semgrep && \
+    # Install opengrep (fork of semgrep with more features)
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then OPENGREP_ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then OPENGREP_ARCH="aarch64"; else OPENGREP_ARCH="x86_64"; fi && \
+    OPENGREP_VERSION=$(curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep "tag_name" | cut -d ":" -f 2 | tr -d " ,\"") && \
+    curl -L "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep-${OPENGREP_VERSION}-${OPENGREP_ARCH}-unknown-linux-musl.tar.gz" -o /tmp/opengrep.tar.gz && \
+    tar -xzf /tmp/opengrep.tar.gz -C /usr/local/bin/ --strip-components=1 && \
+    rm /tmp/opengrep.tar.gz && \
     # GraphQL Clairvoyance - GraphQL schema enumeration
     pipx install --global clairvoyance && \
     pipx install --global xsstrike && \

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -288,7 +288,7 @@ RUN pipx install --global bloodhound && \
     pipx install --global ropper && \
     # Install opengrep (fork of semgrep with more features)
     ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then OPENGREP_ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then OPENGREP_ARCH="aarch64"; else OPENGREP_ARCH="x86_64"; fi && \
+    if [ "$ARCH" = "x86_64" ]; then OPENGREP_ARCH="x86"; elif [ "$ARCH" = "aarch64" ]; then OPENGREP_ARCH="aarch64"; else OPENGREP_ARCH="x86_64"; fi && \
     OPENGREP_VERSION=$(curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep "tag_name" | cut -d ":" -f 2 | tr -d " ,\"") && \
     curl -L "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep-core_linux_${OPENGREP_ARCH}.tar.gz" -o /tmp/opengrep.tar.gz && \
     tar -xzf /tmp/opengrep.tar.gz -C /usr/local/bin/ --strip-components=1 && \

--- a/src/modules/config/system/environment.yaml
+++ b/src/modules/config/system/environment.yaml
@@ -202,11 +202,11 @@ cyber_tools:
     preference: preferred
     caps: [web_crawling, web_recon]
     canary: "katana -h"
-  semgrep:
+  opengrep:
     description: "Static source code analysis"
     preference: preferred
     caps: [sast]
-    canary: "semgrep -h"
+    canary: "opengrep -h"
 
   # DNS/Recon
   dnsrecon:


### PR DESCRIPTION
## Summary

The OpenGrep release assets use `x86` instead of `x86_64` for the architecture suffix:
- `opengrep-core_linux_x86.tar.gz` (not `opengrep-core_linux_x86_64.tar.gz`)
- `opengrep-core_linux_aarch64.tar.gz`

This fix updates the Dockerfile to use the correct architecture mapping.

## Changes

- Changed `OPENGREP_ARCH=x86_64` to `OPENGREP_ARCH=x86` for Linux AMD64 builds

Closes #148